### PR TITLE
Fix fallback for missing dotenv

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1,7 +1,12 @@
 import os
 from dataclasses import dataclass
 from typing import Dict
-from dotenv import load_dotenv
+try:
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover - allow running without package
+    def load_dotenv() -> None:
+        """Fallback no-op when python-dotenv is absent."""
+        pass
 
 # .env 파일 로드
 load_dotenv()


### PR DESCRIPTION
## Summary
- handle missing `python-dotenv` gracefully by providing a fallback no-op implementation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68411e48cde483239115aa212831c44a