### PR TITLE
fix(web): POST 요청 시 빈 body 에러 수정

### DIFF
--- a/packages/web/src/lib/api-client.ts
+++ b/packages/web/src/lib/api-client.ts
@@ -84,7 +84,7 @@ export async function getOrdersSummary(): Promise<SummaryResponse> {
  * 주문 확인 처리
  */
 export async function confirmOrders(): Promise<ConfirmResponse> {
-  return api.post('api/orders/confirm').json<ConfirmResponse>();
+  return api.post('api/orders/confirm', { json: {} }).json<ConfirmResponse>();
 }
 
 /**
@@ -94,7 +94,7 @@ export async function confirmSingleOrder(rowNumber: number): Promise<{
   success: boolean;
   message: string;
 }> {
-  return api.post(`api/orders/${rowNumber}/confirm`).json<{
+  return api.post(`api/orders/${rowNumber}/confirm`, { json: {} }).json<{
     success: boolean;
     message: string;
   }>();


### PR DESCRIPTION
## 🐛 버그 수정

주문 확인 기능(`POST /api/orders/confirm`) 실패 문제를 수정했습니다.

### 에러 로그
```
FastifyError: Body cannot be empty when content-type is set to 'application/json'
code: FST_ERR_CTP_EMPTY_JSON_BODY
statusCode: 400
```

## 🔍 원인 분석

### 1. 클라이언트 설정
`packages/web/src/lib/api-client.ts`에서 모든 요청에 `Content-Type: application/json` 헤더를 기본으로 설정

```typescript
export const api = ky.create({
  headers: {
    'Content-Type': 'application/json',
  },
});
```

### 2. body 없는 POST 요청
```typescript
// Before
export async function confirmOrders() {
  return api.post('api/orders/confirm').json(); // body 없음
}

export async function confirmSingleOrder(rowNumber: number) {
  return api.post(`api/orders/${rowNumber}/confirm`).json(); // body 없음
}
```

### 3. Fastify 검증
Fastify는 `Content-Type: application/json`이 설정되어 있으면 유효한 JSON body를 기대하므로, 빈 body에 대해 에러 발생

## ✅ 해결 방법

POST 요청 시 빈 객체 `{}` 전송

```typescript
// After
export async function confirmOrders() {
  return api.post('api/orders/confirm', { json: {} }).json();
}

export async function confirmSingleOrder(rowNumber: number) {
  return api.post(`api/orders/${rowNumber}/confirm`, { json: {} }).json();
}
```

## 📋 변경사항

### 수정된 파일
- `packages/web/src/lib/api-client.ts`
  - `confirmOrders()`: body에 빈 객체 추가
  - `confirmSingleOrder()`: body에 빈 객체 추가

## 🧪 테스트

- ✅ web 패키지 빌드 성공
- ⚠️ 실제 API 서버 연동 테스트 필요 (로컬 환경에서 확인 권장)

## 🔗 관련 이슈

Closes #45

## 💡 참고사항

- API 엔드포인트는 body를 요구하지 않지만, `Content-Type: application/json`이 설정되어 있으므로 빈 객체를 전송
- 향후 비슷한 문제를 방지하려면:
  - 옵션 1: body가 필요 없는 POST는 GET으로 변경 검토 (의미론적으로는 POST가 맞음)
  - 옵션 2: ky 설정에서 body 없을 때 Content-Type 자동 제거
  - 옵션 3: 현재 방식 유지 (가장 간단하고 안전)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)