### PR TITLE
feat(security): 보안 취약점 자동화 검사 시스템 구축 (#50)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# ⚠️ 참고: Dependabot은 pnpm-lock.yaml을 공식적으로 지원하지 않습니다.
+# 이 프로젝트는 pnpm monorepo이므로 Dependabot의 자동 PR은 제한적일 수 있습니다.
+# pnpm을 완전히 지원하는 Renovate (https://github.com/renovatebot/renovate) 사용을 권장합니다.
+#
+# Dependabot은 보안 알림(Security Alerts)용으로만 활용하고,
+# 실제 의존성 업데이트는 Security Audit 워크플로우나 수동으로 진행하세요.
+
+version: 2
+updates:
+  # 루트 패키지 의존성
+  # monorepo 전체를 관리하는 루트 pnpm-workspace
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"
+      timezone: "Asia/Seoul"
+    labels:
+      - "dependencies"
+      - "security"
+    open-pull-requests-limit: 10
+    groups:
+      security-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+
+  # GitHub Actions 워크플로우 의존성
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"
+      timezone: "Asia/Seoul"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,241 @@
+name: Security Audit
+
+on:
+  schedule:
+    # 매주 월요일 03:00 UTC (한국시간 12:00)
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - dev
+    paths:
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'packages/*/package.json'
+
+jobs:
+  audit:
+    name: Security Vulnerability Scan
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run pnpm audit
+        id: audit
+        continue-on-error: true
+        run: |
+          set +e
+          pnpm audit --json --audit-level=moderate 2>audit-stderr.log | tee audit-result.json
+          AUDIT_EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+
+          echo "audit_exit_code=$AUDIT_EXIT_CODE" >> $GITHUB_OUTPUT
+          echo "Audit exit code: $AUDIT_EXIT_CODE"
+
+      - name: Parse audit results
+        id: check
+        run: |
+          set +e
+
+          AUDIT_EXIT_CODE="${{ steps.audit.outputs.audit_exit_code }}"
+
+          # audit 명령이 실패했는데 결과 파일이 없다면 워크플로우 실패
+          if [ ! -f audit-result.json ]; then
+            if [ "$AUDIT_EXIT_CODE" != "0" ]; then
+              echo "::error::pnpm audit 실행 실패 (exit code: $AUDIT_EXIT_CODE)"
+              exit 1
+            fi
+            echo "has_vulnerabilities=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # jq를 사용해서 취약점 개수 파싱
+          HIGH=$(cat audit-result.json | jq -r '.metadata.vulnerabilities.high // 0' 2>/dev/null || echo "0")
+          MODERATE=$(cat audit-result.json | jq -r '.metadata.vulnerabilities.moderate // 0' 2>/dev/null || echo "0")
+          CRITICAL=$(cat audit-result.json | jq -r '.metadata.vulnerabilities.critical // 0' 2>/dev/null || echo "0")
+
+          TOTAL=$((CRITICAL + HIGH + MODERATE))
+
+          echo "critical=$CRITICAL" >> $GITHUB_OUTPUT
+          echo "high=$HIGH" >> $GITHUB_OUTPUT
+          echo "moderate=$MODERATE" >> $GITHUB_OUTPUT
+          echo "total=$TOTAL" >> $GITHUB_OUTPUT
+
+          echo "취약점 요약: Critical=$CRITICAL, High=$HIGH, Moderate=$MODERATE, Total=$TOTAL"
+
+          if [ $TOTAL -gt 0 ]; then
+            echo "has_vulnerabilities=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_vulnerabilities=false" >> $GITHUB_OUTPUT
+          fi
+
+          set -e
+
+      - name: Create issue on vulnerabilities
+        if: steps.check.outputs.has_vulnerabilities == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const date = new Date().toISOString().split('T')[0];
+            const title = `[Security] pnpm audit 취약점 발견 - ${date}`;
+
+            const critical = '${{ steps.check.outputs.critical }}';
+            const high = '${{ steps.check.outputs.high }}';
+            const moderate = '${{ steps.check.outputs.moderate }}';
+            const total = '${{ steps.check.outputs.total }}';
+
+            // audit 결과 요약 생성 (전체 JSON 대신 요약만)
+            let auditData = '';
+            try {
+              const rawData = fs.readFileSync('audit-result.json', 'utf8');
+              const parsed = JSON.parse(rawData);
+
+              // npm v8+ vulnerabilities 구조와 npm v6 advisories 구조 모두 지원
+              let vulnerabilities = [];
+
+              // npm v8+ 구조: parsed.vulnerabilities
+              if (parsed.vulnerabilities && typeof parsed.vulnerabilities === 'object') {
+                vulnerabilities = Object.entries(parsed.vulnerabilities).map(([pkg, data]) => ({
+                  title: data.name || pkg,
+                  severity: data.severity,
+                  module_name: pkg,
+                  version: data.range || data.via?.[0]?.range || 'N/A',
+                  url: data.via?.[0]?.url || (data.via?.[0] && typeof data.via[0] === 'string' ? `https://npmjs.com/advisories/${data.via[0]}` : 'N/A')
+                }));
+              }
+              // npm v6 구조: parsed.advisories (fallback)
+              else if (parsed.advisories && typeof parsed.advisories === 'object') {
+                vulnerabilities = Object.values(parsed.advisories).map(adv => ({
+                  title: adv.title,
+                  severity: adv.severity,
+                  module_name: adv.module_name,
+                  version: adv.findings?.[0]?.version || 'N/A',
+                  url: adv.url || 'N/A'
+                }));
+              }
+
+              // 상위 10개 취약점만 추출
+              const topVulns = vulnerabilities.slice(0, 10);
+              if (topVulns.length > 0) {
+                auditData = topVulns.map(vuln =>
+                  `- **${vuln.title}** (${vuln.severity})\n  - Package: \`${vuln.module_name}@${vuln.version}\`\n  - More info: ${vuln.url}`
+                ).join('\n\n');
+              } else {
+                auditData = '취약점 상세 정보를 파싱할 수 없습니다. 아티팩트를 확인하세요.';
+              }
+            } catch (e) {
+              auditData = `취약점 상세 정보를 파싱할 수 없습니다. 에러: ${e.message}\n아티팩트를 확인하세요.`;
+            }
+
+            const body = `## 보안 취약점 자동 검사 결과
+
+**검사 일시**: ${new Date().toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' })}
+**워크플로우**: ${context.workflow}
+**실행 번호**: #${context.runNumber}
+**브랜치**: ${context.ref}
+
+### 취약점 요약
+
+| 심각도 | 개수 |
+|--------|------|
+| Critical | ${critical} |
+| High | ${high} |
+| Moderate | ${moderate} |
+| **Total** | **${total}** |
+
+### 발견된 취약점 (상위 10개)
+
+${auditData}
+
+### 조치 방법
+
+1. 로컬에서 \`pnpm audit\` 실행하여 전체 취약점 확인
+2. \`pnpm update\` 또는 \`pnpm audit fix\` 실행
+3. 수동 업데이트가 필요한 경우 package.json 직접 수정
+4. 수정 후 테스트 및 빌드 확인
+5. PR 생성 및 머지
+
+### 참고 링크
+
+- [워크플로우 실행 로그](${context.payload.repository.html_url}/actions/runs/${context.runId})
+- [전체 audit 결과 (아티팩트)](${context.payload.repository.html_url}/actions/runs/${context.runId}#artifacts)
+- [pnpm audit 문서](https://pnpm.io/cli/audit)
+
+---
+자동 생성된 이슈입니다.
+            `;
+
+            // 기존 열린 보안 이슈가 있는지 확인 (security 라벨만으로 검색)
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security'
+            });
+
+            const existingIssue = issues.data.find(issue =>
+              issue.title.includes('[Security] pnpm audit 취약점 발견') &&
+              issue.labels.some(label => label.name === 'automated')
+            );
+
+            if (existingIssue) {
+              // 기존 이슈에 코멘트 추가
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssue.number,
+                body: `### 새로운 검사 결과 (${date})
+
+${body}`
+              });
+              console.log(`기존 이슈 #${existingIssue.number}에 코멘트 추가됨`);
+            } else {
+              // 새 이슈 생성
+              const issue = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: body,
+                labels: ['security', 'automated', 'dependencies']
+              });
+              console.log(`새 이슈 #${issue.data.number} 생성됨`);
+            }
+
+      - name: Upload audit results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-audit-results
+          path: |
+            audit-result.json
+            audit-stderr.log
+          retention-days: 30
+
+      - name: Fail workflow if vulnerabilities found
+        if: steps.check.outputs.has_vulnerabilities == 'true'
+        run: |
+          echo "::error::보안 취약점이 발견되었습니다. 이슈를 확인하고 조치하세요."
+          exit 1


### PR DESCRIPTION
## 요약

Dependabot과 GitHub Actions 워크플로우를 통한 자동 보안 검사 시스템을 구축했습니다.

## 구현 내용

### 1. Dependabot 설정 (`.github/dependabot.yml`)
- 루트 패키지 의존성 자동 업데이트 (주간)
- GitHub Actions 워크플로우 의존성 자동 업데이트
- pnpm 미지원에 대한 경고 및 Renovate 권장 안내
- security 업데이트를 그룹으로 묶어 PR 노이즈 감소

### 2. Security Audit 워크플로우 (`.github/workflows/security-audit.yml`)
- 매주 월요일 03:00 UTC (한국시간 12:00) 자동 실행
- package.json, pnpm-lock.yaml 변경 시 자동 실행
- pnpm audit 실행 및 결과 파싱 (jq 사용)
- 취약점 발견 시 자동 이슈 생성 또는 기존 이슈에 코멘트 추가
- 이슈 본문은 요약만 포함 (상위 10개 취약점)
- 전체 audit 결과는 아티팩트로 업로드 (30일 보관)
- 취약점 발견 시 워크플로우 실패 처리
- npm v6/v8+ 출력 구조 모두 지원

## 주요 기능

### 자동 취약점 검사
- pnpm audit를 정기적으로 실행하여 보안 취약점 자동 감지
- 심각도별 (Critical, High, Moderate) 취약점 개수 파싱
- audit 실행 실패 시 워크플로우 실패 처리

### 자동 이슈 관리
- 취약점 발견 시 `[Security]` 라벨로 이슈 자동 생성
- 기존 열린 보안 이슈가 있으면 코멘트로 추가
- 취약점 요약 테이블 및 상위 10개 취약점 정보 포함
- 조치 방법 및 참고 링크 자동 추가

### 아티팩트 보관
- audit 결과 JSON 파일 30일간 보관
- stderr 로그도 함께 보관하여 문제 추적 용이

## 코드 리뷰 반영 내역

### codex-cli 1차 리뷰
- ✅ Dependabot pnpm 미지원 경고 추가
- ✅ 각 패키지별 엔트리 제거, 루트만 유지
- ✅ pnpm audit 중복 실행 제거 (tee 사용)
- ✅ jq로 정확한 취약점 개수 파싱
- ✅ Cron 주석 수정 (UTC vs KST 명확히)
- ✅ 이슈 본문 크기 제한 (요약만 포함)
- ✅ 라벨 필터링 완화
- ✅ 취약점 발견 시 워크플로우 실패 처리

### codex-cli 2차 리뷰
- ✅ audit 실행 실패 시 워크플로우 즉시 실패
- ✅ npm v8+ vulnerabilities 구조 지원 추가
- ✅ audit_exit_code 활용하여 실패 감지
- ✅ 에러 메시지 개선

## 테스트

### 로컬 pnpm audit 결과
```
3 vulnerabilities found
Severity: 3 high
```

- xlsx@0.18.5: Prototype Pollution (HIGH)
- xlsx@0.18.5: ReDoS (HIGH)
- glob@10.3.10: Command injection (HIGH)

워크플로우가 이를 정확히 감지하고 이슈를 생성할 것으로 예상됩니다.

## 향후 계획

- 워크플로우가 실제로 실행되면 동작 확인
- 필요시 Renovate 도입 검토 (pnpm 완전 지원)
- 보안 취약점 발견 시 Slack/Discord 알림 추가 고려

Resolves #50

---
codex-cli 코드 리뷰 완료