### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [dev, main]
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
     name: Lint and Test


### PR DESCRIPTION
Potential fix for [https://github.com/fomalhaut84/myTangerine/security/code-scanning/1](https://github.com/fomalhaut84/myTangerine/security/code-scanning/1)

To fix the problem, add an explicit `permissions:` block limiting the GITHUB_TOKEN permissions to the minimum required for the workflow's jobs. For most CI workflows such as linting, testing, and uploading coverage reports, `contents: read` is sufficient, as no write operations to the repository are performed. The most reliable approach is placing a top-level `permissions:` block immediately after the workflow `name:` and `on:` section, before the `jobs:` key. This ensures all jobs default to the specified least privilege, unless individual jobs override it. No additional imports or definitions are required; the fix is a pure change to the YAML workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
