### PR TITLE
feat(dashboard): 대시보드 개선 - 선물 통계 및 주문 분리 (#108)

### DIFF
--- a/packages/web/src/app/dashboard/page.tsx
+++ b/packages/web/src/app/dashboard/page.tsx
@@ -1,13 +1,13 @@
 /**
  * 대시보드 페이지
+ * 신규 주문과 완료 주문을 명확하게 분리하여 표시
  */
 
 import { SummaryCard } from '@/components/dashboard/SummaryCard';
 import { RecentOrders } from '@/components/dashboard/RecentOrders';
 import { QuickActions } from '@/components/dashboard/QuickActions';
-import { MonthlyTrendChart } from '@/components/dashboard/MonthlyTrendChart';
-import { ProductRatioChart } from '@/components/dashboard/ProductRatioChart';
-import { CompletedOrdersStats } from '@/components/dashboard/CompletedOrdersStats';
+import { NewOrdersPanel } from '@/components/dashboard/NewOrdersPanel';
+import { OrderStatsPanel } from '@/components/dashboard/OrderStatsPanel';
 
 export default function DashboardPage() {
   return (
@@ -17,35 +17,44 @@ export default function DashboardPage() {
           대시보드
         </h1>
 
+        {/* 상단: 신규 주문 요약 + 최근 주문 */}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* 왼쪽: 주문 요약 */}
-          <div className="lg:col-span-1">
+          <div className="lg:col-span-1 space-y-6">
             <SummaryCard />
+            <QuickActions />
           </div>
-
-          {/* 중앙: 최근 주문 */}
           <div className="lg:col-span-2">
             <RecentOrders />
           </div>
         </div>
 
-        {/* 완료 주문 통계 영역 */}
-        <div className="mt-8">
-          <CompletedOrdersStats />
+        {/* 중앙: 신규 주문 현황 + 완료 주문 통계 (2열) */}
+        <div className="mt-8 grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* 신규 주문 현황 */}
+          <div className="bg-white rounded-xl shadow-sm p-6">
+            <NewOrdersPanel />
+          </div>
+
+          {/* 완료 주문 통계 (컴팩트 모드) */}
+          <div className="bg-white rounded-xl shadow-sm p-6">
+            <OrderStatsPanel
+              title="완료 주문 통계"
+              scope="completed"
+              showCharts={false}
+              showGiftStats={true}
+              compact={true}
+            />
+          </div>
         </div>
 
-        {/* 기존 차트 영역 */}
-        <div className="mt-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
-          {/* 월별 추이 차트 */}
-          <MonthlyTrendChart />
-
-          {/* 상품 비율 차트 */}
-          <ProductRatioChart />
-        </div>
-
-        {/* 하단: 빠른 작업 */}
-        <div className="mt-6 max-w-md">
-          <QuickActions />
+        {/* 하단: 완료 주문 상세 통계 (차트 포함) */}
+        <div className="mt-8 bg-white rounded-xl shadow-sm p-6">
+          <OrderStatsPanel
+            title="완료 주문 상세 분석"
+            scope="completed"
+            showCharts={true}
+            showGiftStats={true}
+          />
         </div>
       </div>
     </div>

--- a/packages/web/src/components/dashboard/NewOrdersPanel.tsx
+++ b/packages/web/src/components/dashboard/NewOrdersPanel.tsx
@@ -1,0 +1,116 @@
+/**
+ * 신규 주문 현황 패널
+ * 처리 대기 중인 신규 주문 통계를 표시
+ */
+
+'use client';
+
+import { useOrderStats } from '@/hooks/use-stats';
+import { Card } from '@/components/common/Card';
+import { Package, TrendingUp, Gift, ShoppingCart } from 'lucide-react';
+
+export function NewOrdersPanel() {
+  // scope='new'일 때는 기간 필터 없이 모든 대기 주문을 조회
+  // API에서 scope='new'인 경우 range를 무시하므로 기본값만 전달
+  const { data, isLoading, error } = useOrderStats({
+    scope: 'new',
+    metric: 'quantity',
+  });
+
+  if (isLoading) {
+    return (
+      <Card title="신규 주문 현황">
+        <div className="animate-pulse space-y-3">
+          <div className="h-16 bg-gray-200 rounded"></div>
+          <div className="h-16 bg-gray-200 rounded"></div>
+        </div>
+      </Card>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <Card title="신규 주문 현황">
+        <div className="text-gray-500 text-sm">
+          데이터를 불러올 수 없습니다.
+        </div>
+      </Card>
+    );
+  }
+
+  const { summary, sections } = data;
+
+  // 선물 비율 계산
+  const giftCount = sections?.gifts?.orderCount || 0;
+  const salesCount = sections?.sales?.orderCount || 0;
+  const totalCount = summary.orderCount;
+  const giftRatio = totalCount > 0 ? Math.round((giftCount / totalCount) * 100) : 0;
+
+  return (
+    <Card title="신규 주문 현황">
+      <div className="space-y-4">
+        {/* 대기 건수 */}
+        <div className="flex items-center justify-between p-4 bg-amber-50 rounded-lg">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-amber-100 rounded-lg">
+              <Package className="h-5 w-5 text-amber-600" />
+            </div>
+            <div>
+              <p className="text-sm text-gray-600">처리 대기</p>
+              <p className="text-2xl font-bold text-amber-600">
+                {totalCount}건
+              </p>
+            </div>
+          </div>
+          <div className="text-right">
+            <p className="text-sm text-gray-600">예상 매출</p>
+            <p className="text-lg font-semibold text-gray-900">
+              {summary.totalRevenue.toLocaleString()}원
+            </p>
+          </div>
+        </div>
+
+        {/* 판매/선물 비율 */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="flex items-center gap-2 p-3 bg-blue-50 rounded-lg">
+            <ShoppingCart className="h-4 w-4 text-blue-600" />
+            <div>
+              <p className="text-xs text-gray-600">판매</p>
+              <p className="text-lg font-bold text-blue-600">{salesCount}건</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 p-3 bg-purple-50 rounded-lg">
+            <Gift className="h-4 w-4 text-purple-600" />
+            <div>
+              <p className="text-xs text-gray-600">선물</p>
+              <p className="text-lg font-bold text-purple-600">{giftCount}건</p>
+            </div>
+          </div>
+        </div>
+
+        {/* 상품별 수량 */}
+        <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+          <div className="flex items-center gap-2">
+            <TrendingUp className="h-4 w-4 text-gray-600" />
+            <span className="text-sm text-gray-600">상품 구성</span>
+          </div>
+          <div className="flex gap-4 text-sm">
+            <span className="text-orange-600 font-medium">
+              5kg: {summary.total5kgQty}박스
+            </span>
+            <span className="text-green-600 font-medium">
+              10kg: {summary.total10kgQty}박스
+            </span>
+          </div>
+        </div>
+
+        {/* 선물 비율 안내 */}
+        {giftRatio > 0 && (
+          <div className="text-xs text-gray-500 text-center">
+            전체 중 선물 주문 비율: {giftRatio}%
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/packages/web/src/components/dashboard/OrderStatsPanel.tsx
+++ b/packages/web/src/components/dashboard/OrderStatsPanel.tsx
@@ -1,0 +1,204 @@
+/**
+ * 주문 통계 패널 컴포넌트 (범용)
+ * scope에 따라 신규/완료/전체 주문 통계를 표시
+ */
+
+'use client';
+
+import { useState } from 'react';
+import { useOrderStats } from '@/hooks/use-stats';
+import { KPICard } from '@/components/stats/KPICard';
+import { LineChartStats } from '@/components/stats/LineChartStats';
+import { DonutChartStats } from '@/components/stats/DonutChartStats';
+import { BarChartStats } from '@/components/stats/BarChartStats';
+import { Card } from '@/components/common/Card';
+import type { StatsMetric, StatsRange, StatsScope } from '@/types/api';
+
+interface OrderStatsPanelProps {
+  /** 패널 제목 */
+  title: string;
+  /** 주문 범위 (new: 신규, completed: 완료, all: 전체) */
+  scope: StatsScope;
+  /** 차트 표시 여부 (기본: true) */
+  showCharts?: boolean;
+  /** 선물 통계 표시 여부 */
+  showGiftStats?: boolean;
+  /** 컴팩트 모드 (차트 간소화) */
+  compact?: boolean;
+}
+
+export function OrderStatsPanel({
+  title,
+  scope,
+  showCharts = true,
+  showGiftStats = false,
+  compact = false,
+}: OrderStatsPanelProps) {
+  const [range, setRange] = useState<StatsRange>('12m');
+  const [metric, setMetric] = useState<StatsMetric>('quantity');
+
+  const { data, isLoading, error, isFetching } = useOrderStats({
+    scope,
+    range,
+    metric,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <h2 className="text-xl font-bold text-gray-900">{title}</h2>
+        <div className="animate-pulse">
+          <div className="h-32 bg-gray-200 rounded"></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card title={title}>
+        <div className="text-red-600">
+          {title} 데이터를 불러오는 중 오류가 발생했습니다.
+        </div>
+      </Card>
+    );
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const { summary, sections, series, totalsByProduct } = data;
+
+  // 선물 비율 계산
+  const giftRatio = sections && sections.overall.orderCount > 0
+    ? Math.round((sections.gifts.orderCount / sections.overall.orderCount) * 100)
+    : 0;
+
+  return (
+    <div className="space-y-4">
+      {/* 헤더 및 필터 */}
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div className="flex items-center gap-3">
+          <h2 className="text-xl font-bold text-gray-900">{title}</h2>
+          {showGiftStats && giftRatio > 0 && (
+            <span className="px-2 py-1 text-xs font-medium bg-purple-100 text-purple-700 rounded-full">
+              선물 {giftRatio}%
+            </span>
+          )}
+          {isFetching && !isLoading && (
+            <div className="animate-spin h-4 w-4 border-2 border-blue-600 rounded-full border-t-transparent"></div>
+          )}
+        </div>
+        <div className="flex gap-2">
+          <select
+            value={range}
+            onChange={(e) => {
+              const value = e.target.value;
+              if (value === '6m' || value === '12m') {
+                setRange(value);
+              }
+            }}
+            disabled={isFetching}
+            aria-label="조회 기간 선택"
+            className="px-3 py-1.5 border border-gray-300 rounded-lg bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            <option value="6m">6개월</option>
+            <option value="12m">12개월</option>
+          </select>
+          <select
+            value={metric}
+            onChange={(e) => {
+              const value = e.target.value;
+              if (value === 'quantity' || value === 'amount') {
+                setMetric(value);
+              }
+            }}
+            disabled={isFetching}
+            aria-label="조회 지표 선택"
+            className="px-3 py-1.5 border border-gray-300 rounded-lg bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            <option value="quantity">수량</option>
+            <option value="amount">금액</option>
+          </select>
+        </div>
+      </div>
+
+      {/* KPI 카드들 */}
+      <div className={`grid gap-3 ${compact ? 'grid-cols-2' : 'grid-cols-2 lg:grid-cols-4'}`}>
+        <KPICard
+          title="총 매출"
+          value={summary.totalRevenue}
+          unit="원"
+          variant="primary"
+        />
+        <KPICard
+          title="주문 수"
+          value={summary.orderCount}
+          unit="건"
+          variant="default"
+        />
+        {!compact && (
+          <>
+            <KPICard
+              title="5kg"
+              value={summary.total5kgQty}
+              unit="박스"
+              subtitle={`${summary.total5kgAmount.toLocaleString()}원`}
+              variant="warning"
+            />
+            <KPICard
+              title="10kg"
+              value={summary.total10kgQty}
+              unit="박스"
+              subtitle={`${summary.total10kgAmount.toLocaleString()}원`}
+              variant="success"
+            />
+          </>
+        )}
+      </div>
+
+      {/* 선물/판매 비율 표시 */}
+      {showGiftStats && sections && (
+        <div className="grid grid-cols-2 gap-3">
+          <div className="p-3 bg-blue-50 rounded-lg">
+            <p className="text-xs text-gray-600">판매 주문</p>
+            <p className="text-lg font-bold text-blue-600">
+              {sections.sales.orderCount}건
+            </p>
+            <p className="text-xs text-gray-500">
+              {sections.sales.totalRevenue.toLocaleString()}원
+            </p>
+          </div>
+          <div className="p-3 bg-purple-50 rounded-lg">
+            <p className="text-xs text-gray-600">선물 주문</p>
+            <p className="text-lg font-bold text-purple-600">
+              {sections.gifts.orderCount}건
+            </p>
+            <p className="text-xs text-gray-500">
+              {sections.gifts.total5kgQty + sections.gifts.total10kgQty}박스
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* 차트 */}
+      {showCharts && !compact && (
+        <>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <LineChartStats data={series} metric={metric} />
+            {totalsByProduct.length > 0 && (
+              <DonutChartStats data={totalsByProduct} metric={metric} />
+            )}
+          </div>
+          <BarChartStats data={series} metric={metric} />
+        </>
+      )}
+
+      {/* 기간 표시 */}
+      <div className="text-xs text-gray-500 text-center">
+        {summary.dateRange.start} ~ {summary.dateRange.end}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/dashboard/SummaryCard.tsx
+++ b/packages/web/src/components/dashboard/SummaryCard.tsx
@@ -1,15 +1,23 @@
 /**
  * 주문 요약 카드 컴포넌트
+ * 신규 주문의 요약 정보와 선물 비율을 표시
  */
 
 'use client';
 
 import { useOrdersSummary } from '@/hooks/use-orders';
+import { useOrderStats } from '@/hooks/use-stats';
 import { Card } from '@/components/common/Card';
 import { SummaryCardSkeleton } from '@/components/common/DashboardSkeleton';
+import { Gift } from 'lucide-react';
 
 export function SummaryCard() {
   const { data, isLoading, error } = useOrdersSummary();
+  // 선물 비율 계산용 Stats API 호출
+  const { data: statsData, isLoading: statsLoading, error: statsError } = useOrderStats({
+    scope: 'new',
+    metric: 'quantity',
+  });
 
   if (isLoading) {
     return <SummaryCardSkeleton />;
@@ -17,7 +25,7 @@ export function SummaryCard() {
 
   if (error) {
     return (
-      <Card title="주문 요약">
+      <Card title="신규 주문 요약">
         <div className="text-red-600">
           요약 정보를 불러오는 중 오류가 발생했습니다.
         </div>
@@ -27,7 +35,7 @@ export function SummaryCard() {
 
   if (!data?.success || !data?.summary) {
     return (
-      <Card title="주문 요약">
+      <Card title="신규 주문 요약">
         <div className="text-gray-500">요약 정보가 없습니다.</div>
       </Card>
     );
@@ -35,9 +43,37 @@ export function SummaryCard() {
 
   const { summary } = data;
 
+  // 선물 비율 계산
+  const sections = statsData?.sections;
+  const giftCount = sections?.gifts?.orderCount || 0;
+  const totalCount = sections?.overall?.orderCount || 0;
+  const giftRatio = totalCount > 0 ? Math.round((giftCount / totalCount) * 100) : 0;
+
   return (
-    <Card title="주문 요약">
-      <div className="space-y-6">
+    <Card title="신규 주문 요약">
+      <div className="space-y-4">
+        {/* 선물 비율 배지 */}
+        {statsLoading ? (
+          <div className="flex items-center gap-2 p-2 bg-gray-50 rounded-lg animate-pulse">
+            <div className="h-4 w-4 bg-gray-200 rounded"></div>
+            <div className="h-4 w-24 bg-gray-200 rounded"></div>
+          </div>
+        ) : statsError ? (
+          <div className="flex items-center gap-2 p-2 bg-red-50 rounded-lg">
+            <Gift className="h-4 w-4 text-red-400" />
+            <span className="text-sm text-red-600">
+              선물 통계를 불러올 수 없습니다
+            </span>
+          </div>
+        ) : giftRatio > 0 ? (
+          <div className="flex items-center gap-2 p-2 bg-purple-50 rounded-lg">
+            <Gift className="h-4 w-4 text-purple-600" />
+            <span className="text-sm text-purple-700">
+              선물 주문 {giftCount}건 ({giftRatio}%)
+            </span>
+          </div>
+        ) : null}
+
         {/* 5kg 요약 */}
         <div className="flex justify-between items-center p-4 bg-orange-50 rounded-lg">
           <div>


### PR DESCRIPTION
## Summary

- 신규 주문과 완료 주문을 명확하게 분리하여 표시
- 대시보드에 선물 관련 통계(선물 비율, 건수) 추가
- 범용 `OrderStatsPanel` 컴포넌트 생성으로 코드 재사용성 개선

## 주요 변경사항

### 새 컴포넌트
- **OrderStatsPanel**: `scope` 파라미터로 신규/완료/전체 주문 통계를 표시하는 범용 컴포넌트
  - 필터(기간/지표) 지원
  - compact 모드 지원
  - 선물 통계 표시 옵션
- **NewOrdersPanel**: 처리 대기 중인 신규 주문 현황 표시
  - 판매/선물 주문 구분
  - 상품별 수량 표시

### SummaryCard 개선
- 선물 비율 배지 추가 (Stats API `sections` 활용)
- Stats API 에러 처리 추가 (로딩/에러 상태 표시)

### 대시보드 레이아웃 재구성
```
┌─────────────────────────────────────────────┐
│ 상단: 신규 주문 요약 + 최근 주문            │
├──────────────────────┬──────────────────────┤
│ 신규 주문 현황       │ 완료 주문 통계       │
│ (NewOrdersPanel)     │ (OrderStatsPanel)    │
├──────────────────────┴──────────────────────┤
│ 완료 주문 상세 분석 (차트 포함)             │
│ (OrderStatsPanel)                           │
└─────────────────────────────────────────────┘
```

## codex-cli 코드 리뷰 반영 내역

### 1차 리뷰 피드백
| 우선순위 | 지적 사항 | 조치 |
|---------|----------|------|
| P1 | NewOrdersPanel `range: '12m'` 하드코딩으로 오래된 대기 주문 누락 가능 | range 파라미터 제거, 모든 대기 주문 표시 |
| P2 | SummaryCard stats 쿼리 에러 시 선물 배지 무음 실패 | 로딩/에러 상태별 UI 표시 추가 |
| P2 | OrderStatsPanel 에러 메시지가 어떤 패널인지 구분 불가 | 에러 메시지에 `title` 포함 |
| P2 | select 요소 `as` 캐스팅으로 런타임 타입 체크 부재 | 타입 가드 추가 |
| P3 | select 요소 aria-label 없음 (접근성) | `aria-label` 추가 |

### 반영하지 않은 사항
- **두 OrderStatsPanel의 필터 상태 공유**: 현재 각 패널이 독립적인 필터를 가지고 있어 사용자가 각 패널을 개별 조회할 수 있음. 의도적인 설계로, 추후 UX 피드백에 따라 재검토 예정
- **SummaryCard 중복 API 호출**: summary API와 stats API가 반환하는 데이터 구조가 다르고, summary API가 더 간결한 응답을 제공하므로 현재 구조 유지

## 테스트 결과
- 빌드: ✅ 성공
- 테스트: ✅ 136개 모두 통과 (core 74, web 16, api 46)

## Test plan
- [ ] 대시보드 페이지 로드 시 모든 패널 정상 표시 확인
- [ ] 신규 주문 현황 패널에서 판매/선물 구분 확인
- [ ] 완료 주문 통계 패널에서 기간/지표 필터 동작 확인
- [ ] SummaryCard 선물 비율 배지 표시 확인
- [ ] API 에러 시 적절한 에러 메시지 표시 확인

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)