### PR TITLE
feat: GNB 추가 및 통계 기간 표기 개선 (#110)

### DIFF
--- a/packages/web/src/app/dashboard/page.tsx
+++ b/packages/web/src/app/dashboard/page.tsx
@@ -11,7 +11,7 @@ import { OrderStatsPanel } from '@/components/dashboard/OrderStatsPanel';
 
 export default function DashboardPage() {
   return (
-    <div className="min-h-screen bg-gray-50 p-8">
+    <div className="min-h-[calc(100vh-3.5rem)] bg-gray-50 p-8">
       <div className="max-w-7xl mx-auto">
         <h1 className="text-3xl font-bold text-gray-900 mb-8">
           대시보드

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Providers } from '@/components/providers';
 import { Toaster } from '@/components/ui/sonner';
 import { KeyboardShortcuts } from '@/components/common/KeyboardShortcuts';
+import { GlobalNav } from '@/components/common/GlobalNav';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -29,7 +30,10 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body>
-        <Providers>{children}</Providers>
+        <Providers>
+          <GlobalNav />
+          {children}
+        </Providers>
         <Toaster />
         <KeyboardShortcuts />
       </body>

--- a/packages/web/src/app/stats/page.tsx
+++ b/packages/web/src/app/stats/page.tsx
@@ -9,6 +9,7 @@ import { DonutChartStats } from '@/components/stats/DonutChartStats';
 import { BarChartStats } from '@/components/stats/BarChartStats';
 import { AreaChartStats } from '@/components/stats/AreaChartStats';
 import { Loader2, Gift, ShoppingCart, BarChart3 } from 'lucide-react';
+import { formatDateRangeKorean } from '@/lib/utils';
 import type { OrderTypeFilter } from '@/types/api';
 
 type StatsRange = '6m' | '12m' | 'custom';
@@ -74,7 +75,12 @@ export default function StatsPage() {
                 <label className="text-sm font-medium">기간:</label>
                 <select
                   value={range}
-                  onChange={(e) => setRange(e.target.value as StatsRange)}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    if (value === '6m' || value === '12m' || value === 'custom') {
+                      setRange(value);
+                    }
+                  }}
                   className="px-3 py-2 border rounded-md text-sm"
                 >
                   <option value="6m">최근 6개월</option>
@@ -108,7 +114,12 @@ export default function StatsPage() {
                 <label className="text-sm font-medium">기준:</label>
                 <select
                   value={metric}
-                  onChange={(e) => setMetric(e.target.value as StatsMetric)}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    if (value === 'quantity' || value === 'amount') {
+                      setMetric(value);
+                    }
+                  }}
                   className="px-3 py-2 border rounded-md text-sm"
                 >
                   <option value="quantity">수량</option>
@@ -202,7 +213,12 @@ export default function StatsPage() {
               <label className="text-sm font-medium">기간:</label>
               <select
                 value={range}
-                onChange={(e) => setRange(e.target.value as StatsRange)}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  if (value === '6m' || value === '12m' || value === 'custom') {
+                    setRange(value);
+                  }
+                }}
                 className="px-3 py-2 border rounded-md text-sm"
               >
                 <option value="6m">최근 6개월</option>
@@ -240,7 +256,12 @@ export default function StatsPage() {
               <label className="text-sm font-medium">기준:</label>
               <select
                 value={metric}
-                onChange={(e) => setMetric(e.target.value as StatsMetric)}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  if (value === 'quantity' || value === 'amount') {
+                    setMetric(value);
+                  }
+                }}
                 className="px-3 py-2 border rounded-md text-sm"
               >
                 <option value="quantity">수량</option>
@@ -257,7 +278,7 @@ export default function StatsPage() {
           title="총 매출"
           value={summary.totalRevenue}
           unit="원"
-          subtitle={`${summary.dateRange.start} ~ ${summary.dateRange.end}`}
+          subtitle={formatDateRangeKorean(summary.dateRange.start, summary.dateRange.end)}
         />
         <KPICard
           title="평균 주문 금액"

--- a/packages/web/src/components/common/GlobalNav.tsx
+++ b/packages/web/src/components/common/GlobalNav.tsx
@@ -1,0 +1,93 @@
+/**
+ * 글로벌 네비게이션 바
+ * 주요 페이지 간 이동을 위한 상단 메뉴
+ */
+
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { LayoutDashboard, BarChart3, Package, Tag } from 'lucide-react';
+
+interface NavItem {
+  href: string;
+  label: string;
+  icon: React.ReactNode;
+}
+
+const navItems: NavItem[] = [
+  {
+    href: '/dashboard',
+    label: '대시보드',
+    icon: <LayoutDashboard className="h-4 w-4" />,
+  },
+  {
+    href: '/stats',
+    label: '통계',
+    icon: <BarChart3 className="h-4 w-4" />,
+  },
+  {
+    href: '/orders',
+    label: '주문관리',
+    icon: <Package className="h-4 w-4" />,
+  },
+  {
+    href: '/labels',
+    label: '라벨',
+    icon: <Tag className="h-4 w-4" />,
+  },
+];
+
+export function GlobalNav() {
+  const pathname = usePathname();
+
+  // 홈페이지('/')에서는 GNB를 숨김
+  if (pathname === '/') {
+    return null;
+  }
+
+  return (
+    <nav className="bg-white border-b border-gray-200 sticky top-0 z-50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between h-14">
+          {/* 로고 */}
+          <Link
+            href="/dashboard"
+            className="flex items-center gap-2 text-orange-600 font-bold text-lg"
+          >
+            <span className="text-2xl">🍊</span>
+            <span className="hidden sm:inline">myTangerine</span>
+          </Link>
+
+          {/* 메뉴 */}
+          <div className="flex items-center gap-1">
+            {navItems.map((item) => {
+              const isActive = pathname === item.href ||
+                (item.href !== '/dashboard' && pathname.startsWith(item.href));
+
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  aria-label={item.label}
+                  className={`
+                    flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium
+                    transition-colors duration-200
+                    ${isActive
+                      ? 'bg-orange-100 text-orange-700'
+                      : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+                    }
+                  `}
+                  aria-current={isActive ? 'page' : undefined}
+                >
+                  {item.icon}
+                  <span className="hidden sm:inline" aria-hidden="true">{item.label}</span>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/packages/web/src/components/dashboard/CompletedOrdersStats.tsx
+++ b/packages/web/src/components/dashboard/CompletedOrdersStats.tsx
@@ -11,6 +11,7 @@ import { LineChartStats } from '@/components/stats/LineChartStats';
 import { DonutChartStats } from '@/components/stats/DonutChartStats';
 import { BarChartStats } from '@/components/stats/BarChartStats';
 import { Card } from '@/components/common/Card';
+import { formatDateRangeKorean } from '@/lib/utils';
 import type { StatsMetric, StatsRange } from '@/types/api';
 
 export function CompletedOrdersStats() {
@@ -63,8 +64,14 @@ export function CompletedOrdersStats() {
         <div className="flex gap-2">
           <select
             value={range}
-            onChange={(e) => setRange(e.target.value as StatsRange)}
+            onChange={(e) => {
+              const value = e.target.value;
+              if (value === '6m' || value === '12m') {
+                setRange(value);
+              }
+            }}
             disabled={isFetching}
+            aria-label="조회 기간 선택"
             className="px-4 py-2 border border-gray-300 rounded-lg bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <option value="6m">최근 6개월</option>
@@ -72,8 +79,14 @@ export function CompletedOrdersStats() {
           </select>
           <select
             value={metric}
-            onChange={(e) => setMetric(e.target.value as StatsMetric)}
+            onChange={(e) => {
+              const value = e.target.value;
+              if (value === 'quantity' || value === 'amount') {
+                setMetric(value);
+              }
+            }}
             disabled={isFetching}
+            aria-label="조회 지표 선택"
             className="px-4 py-2 border border-gray-300 rounded-lg bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <option value="quantity">수량 기준</option>
@@ -127,7 +140,7 @@ export function CompletedOrdersStats() {
 
       {/* 기간 표시 */}
       <div className="text-sm text-gray-500 text-center">
-        데이터 기간: {summary.dateRange.start} ~ {summary.dateRange.end}
+        데이터 기간: {formatDateRangeKorean(summary.dateRange.start, summary.dateRange.end)}
       </div>
     </div>
   );

--- a/packages/web/src/components/dashboard/OrderStatsPanel.tsx
+++ b/packages/web/src/components/dashboard/OrderStatsPanel.tsx
@@ -12,6 +12,7 @@ import { LineChartStats } from '@/components/stats/LineChartStats';
 import { DonutChartStats } from '@/components/stats/DonutChartStats';
 import { BarChartStats } from '@/components/stats/BarChartStats';
 import { Card } from '@/components/common/Card';
+import { formatDateRangeKorean } from '@/lib/utils';
 import type { StatsMetric, StatsRange, StatsScope } from '@/types/api';
 
 interface OrderStatsPanelProps {
@@ -197,7 +198,7 @@ export function OrderStatsPanel({
 
       {/* 기간 표시 */}
       <div className="text-xs text-gray-500 text-center">
-        {summary.dateRange.start} ~ {summary.dateRange.end}
+        {formatDateRangeKorean(summary.dateRange.start, summary.dateRange.end)}
       </div>
     </div>
   );

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -4,3 +4,40 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * YYYY-MM-DD 형식의 날짜 문자열을 한국어 형식으로 변환
+ * @param dateStr - "2025-01-01" 형식의 날짜 문자열
+ * @returns "2025년 1월 1일" 형식의 문자열, 유효하지 않은 입력 시 원본 반환
+ */
+export function formatDateKorean(dateStr: string): string {
+  // 유효하지 않은 입력 처리
+  if (!dateStr || typeof dateStr !== 'string') {
+    return dateStr ?? '';
+  }
+
+  // YYYY-MM-DD 형식 검증
+  const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+  if (!dateRegex.test(dateStr)) {
+    return dateStr; // 형식이 맞지 않으면 원본 반환
+  }
+
+  const [year, month, day] = dateStr.split('-').map(Number);
+
+  // 숫자 변환 실패 처리
+  if (isNaN(year) || isNaN(month) || isNaN(day)) {
+    return dateStr;
+  }
+
+  return `${year}년 ${month}월 ${day}일`;
+}
+
+/**
+ * 날짜 범위를 한국어 형식으로 변환
+ * @param start - 시작 날짜 (YYYY-MM-DD)
+ * @param end - 종료 날짜 (YYYY-MM-DD)
+ * @returns "2025년 1월 1일 ~ 2025년 12월 31일" 형식의 문자열
+ */
+export function formatDateRangeKorean(start: string, end: string): string {
+  return `${formatDateKorean(start)} ~ ${formatDateKorean(end)}`;
+}


### PR DESCRIPTION
## Summary

- 대시보드/통계/주문관리/라벨 페이지 간 이동을 위한 GNB(Global Navigation Bar) 추가
- 통계 기간 계산을 월 1일 기준으로 변경하여 명확한 기간 표시
- 날짜 표기를 "2025년 1월 1일 ~ 2025년 12월 31일" 형식으로 개선

## 주요 변경사항

### 1. GNB (Global Navigation Bar) 추가
- 상단 고정 네비게이션 바 추가
- 메뉴: 대시보드, 통계, 주문관리, 라벨
- 반응형 디자인 (모바일: 아이콘만, 데스크탑: 아이콘+텍스트)
- 현재 페이지 하이라이트
- 홈페이지('/')에서는 GNB 숨김

### 2. 기간 계산 로직 수정
**수정 전**: 오늘 날짜에서 N개월 전 (예: 12월 13일 → 12월 13일)
**수정 후**: 월 1일 기준 (예: 12개월 선택 시 1월 1일 ~ 12월 31일)

```
6개월 선택 (현재: 2025년 12월)
- 시작: 2025년 7월 1일
- 종료: 2025년 12월 31일

12개월 선택 (현재: 2025년 12월)
- 시작: 2025년 1월 1일
- 종료: 2025년 12월 31일
```

### 3. 기간 표기 명확화
- "2025-01-01 ~ 2025-12-31" → "2025년 1월 1일 ~ 2025년 12월 31일"
- 유틸리티 함수 추가: `formatDateKorean`, `formatDateRangeKorean`
- 모든 통계 컴포넌트에 적용

## codex-cli 코드 리뷰 반영 내역

### 1차 리뷰 피드백
| 우선순위 | 지적 사항 | 조치 |
|---------|----------|------|
| P1 | GNB 모바일 접근성: 아이콘만 표시 시 스크린 리더 접근 불가 | `aria-label` 추가, 텍스트에 `aria-hidden` |
| P1 | customEnd 파라미터 무시됨 | customEnd 전달 시 해당 날짜 존중하도록 수정 |
| P2 | 날짜 포맷 함수 에러 처리 부재 | 유효성 검증 추가, 실패 시 원본 반환 |
| P2 | GNB 높이로 인한 불필요한 스크롤바 | `min-h-[calc(100vh-3.5rem)]` 적용 |
| P2 | CompletedOrdersStats 날짜 포맷 미적용 | `formatDateRangeKorean` 적용, 타입 가드/aria-label 추가 |

### 2차 리뷰
- 모든 피드백 반영 확인 완료 ✅

## 변경된 파일
- `packages/web/src/components/common/GlobalNav.tsx` (NEW)
- `packages/web/src/app/layout.tsx`
- `packages/api/src/utils/stats.ts`
- `packages/web/src/lib/utils.ts`
- `packages/web/src/app/dashboard/page.tsx`
- `packages/web/src/app/stats/page.tsx`
- `packages/web/src/components/dashboard/OrderStatsPanel.tsx`
- `packages/web/src/components/dashboard/CompletedOrdersStats.tsx`

## 테스트 결과
- 빌드: ✅ 성공
- 테스트: ✅ 136개 모두 통과 (core 74, web 16, api 46)

## Test plan
- [ ] GNB 표시 확인 (모든 페이지에서)
- [ ] GNB 메뉴 클릭 시 페이지 이동 확인
- [ ] 모바일 화면에서 아이콘만 표시 확인
- [ ] 스크린 리더로 GNB 메뉴 접근 확인
- [ ] 통계 기간 표시 형식 확인 (한국어)
- [ ] 6개월/12개월 선택 시 기간 계산 확인 (월 1일 기준)

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)