### PR TITLE
feat(excel): 주문 목록 Excel 내보내기 기능 추가 (#113)

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -29,6 +29,7 @@
     "@mytangerine/core": "workspace:*",
     "@prisma/client": "^6.0.0",
     "dotenv": "^17.2.3",
+    "exceljs": "^4.4.0",
     "fastify": "^4.0.0",
     "fastify-plugin": "^4.0.0",
     "pdfmake": "^0.2.20",

--- a/packages/api/src/utils/excel-generator.ts
+++ b/packages/api/src/utils/excel-generator.ts
@@ -1,0 +1,187 @@
+/**
+ * Excel 생성 유틸리티
+ * Issue #113: 주문 목록 Excel 내보내기
+ */
+
+import ExcelJS from 'exceljs';
+import type { ExcelTableRow, ExcelOptions } from '@mytangerine/core';
+
+/**
+ * Excel Formula Injection 방지를 위한 문자열 새니타이징
+ * =, +, -, @, Tab, CR, LF 및 공백/제어문자로 시작하는 값은 수식으로 해석될 수 있음
+ * 앞에 작은따옴표(')를 추가하여 텍스트로 강제 처리
+ *
+ * @param value - 새니타이징할 값
+ * @returns 새니타이징된 문자열 또는 원본 값
+ */
+function sanitizeForExcel(value: string | number): string | number {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  // 앞뒤 공백/제어문자 제거 후 검사 (trim 후에도 위험 문자 체크)
+  const trimmed = value.trim();
+
+  // 수식으로 해석될 수 있는 위험한 시작 문자 패턴
+  // =, +, -, @, Tab(\t), CR(\r), LF(\n), 공백 후 수식 문자
+  const dangerousPattern = /^[=+\-@\t\r\n]/;
+
+  if (dangerousPattern.test(trimmed) || dangerousPattern.test(value)) {
+    // 작은따옴표를 앞에 추가하여 텍스트로 강제 처리
+    return `'${value}`;
+  }
+
+  return value;
+}
+
+/**
+ * 시트 이름 새니타이징
+ * Excel에서 허용되지 않는 문자를 제거하고 31자로 제한
+ *
+ * @param name - 원본 시트 이름
+ * @returns 새니타이징된 시트 이름
+ */
+function sanitizeSheetName(name: string): string {
+  // Excel에서 허용되지 않는 문자: : \ / ? * [ ]
+  const sanitized = name.replace(/[:\\/?*[\]]/g, '_');
+  // 시트 이름은 31자 제한
+  return sanitized.slice(0, 31);
+}
+
+/**
+ * Excel 헤더 정의
+ */
+const EXCEL_HEADERS = [
+  { key: '번호', header: '번호', width: 8 },
+  { key: '보내는분_성명', header: '보내는분\n성명', width: 12 },
+  { key: '보내는분_전화번호', header: '보내는분\n전화번호', width: 15 },
+  { key: '받는분_주소', header: '받는분 주소', width: 40 },
+  { key: '받는분_성명', header: '받는분\n성명', width: 12 },
+  { key: '받는분_전화번호', header: '받는분\n전화번호', width: 15 },
+  { key: '수량', header: '수량', width: 8 },
+  { key: '품목명', header: '품목명', width: 12 },
+];
+
+/**
+ * Excel Buffer 생성
+ *
+ * @param rows - Excel 테이블 행 데이터
+ * @param options - Excel 생성 옵션
+ * @returns Excel Buffer를 반환하는 Promise
+ */
+export async function generateExcelBuffer(
+  rows: ExcelTableRow[],
+  options: ExcelOptions = {}
+): Promise<Buffer> {
+  const {
+    title = '현애순(딸) 주문목록',
+    sheetName = '주문목록',
+    includeTimestamp = true,
+    filterDescription,
+  } = options;
+
+  // 워크북 생성
+  const workbook = new ExcelJS.Workbook();
+  workbook.creator = 'myTangerine';
+  workbook.created = new Date();
+
+  // 워크시트 추가 (시트 이름 새니타이징)
+  const worksheet = workbook.addWorksheet(sanitizeSheetName(sheetName));
+
+  // 제목 행 추가
+  let currentRow = 1;
+
+  // 제목 (새니타이징 적용)
+  worksheet.mergeCells(`A${currentRow}:H${currentRow}`);
+  const titleCell = worksheet.getCell(`A${currentRow}`);
+  titleCell.value = sanitizeForExcel(title);
+  titleCell.font = { size: 18, bold: true };
+  titleCell.alignment = { horizontal: 'left', vertical: 'middle' };
+  currentRow++;
+
+  // 생성 일시
+  if (includeTimestamp) {
+    worksheet.mergeCells(`A${currentRow}:H${currentRow}`);
+    const timestampCell = worksheet.getCell(`A${currentRow}`);
+    timestampCell.value = `생성 일시: ${new Date().toLocaleString('ko-KR')}`;
+    timestampCell.font = { size: 10, color: { argb: 'FF666666' } };
+    currentRow++;
+  }
+
+  // 필터 설명 (새니타이징 적용)
+  if (filterDescription) {
+    worksheet.mergeCells(`A${currentRow}:H${currentRow}`);
+    const filterCell = worksheet.getCell(`A${currentRow}`);
+    filterCell.value = sanitizeForExcel(filterDescription);
+    filterCell.font = { size: 10, color: { argb: 'FF666666' } };
+    currentRow++;
+  }
+
+  // 빈 행 추가
+  currentRow++;
+
+  // 헤더 행 설정
+  const headerRow = worksheet.getRow(currentRow);
+  EXCEL_HEADERS.forEach((header, index) => {
+    const cell = headerRow.getCell(index + 1);
+    cell.value = header.header;
+    cell.font = { bold: true };
+    cell.fill = {
+      type: 'pattern',
+      pattern: 'solid',
+      fgColor: { argb: 'FFF2F2F2' },
+    };
+    cell.alignment = { horizontal: 'center', vertical: 'middle', wrapText: true };
+    cell.border = {
+      top: { style: 'thin', color: { argb: 'FFCCCCCC' } },
+      left: { style: 'thin', color: { argb: 'FFCCCCCC' } },
+      bottom: { style: 'thin', color: { argb: 'FFCCCCCC' } },
+      right: { style: 'thin', color: { argb: 'FFCCCCCC' } },
+    };
+  });
+  headerRow.height = 35;
+  currentRow++;
+
+  // 데이터 행 추가 (새니타이징 적용)
+  rows.forEach((row) => {
+    const dataRow = worksheet.getRow(currentRow);
+
+    EXCEL_HEADERS.forEach((header, index) => {
+      const cell = dataRow.getCell(index + 1);
+      const rawValue = row[header.key as keyof ExcelTableRow];
+      cell.value = sanitizeForExcel(rawValue);
+
+      // 주소 컬럼은 좌측 정렬, 나머지는 중앙 정렬
+      const isAddress = header.key === '받는분_주소';
+      cell.alignment = {
+        horizontal: isAddress ? 'left' : 'center',
+        vertical: 'middle',
+        wrapText: true,
+      };
+
+      cell.border = {
+        top: { style: 'thin', color: { argb: 'FFCCCCCC' } },
+        left: { style: 'thin', color: { argb: 'FFCCCCCC' } },
+        bottom: { style: 'thin', color: { argb: 'FFCCCCCC' } },
+        right: { style: 'thin', color: { argb: 'FFCCCCCC' } },
+      };
+    });
+
+    dataRow.height = 25;
+    currentRow++;
+  });
+
+  // 컬럼 너비 설정
+  EXCEL_HEADERS.forEach((header, index) => {
+    worksheet.getColumn(index + 1).width = header.width;
+  });
+
+  // Buffer로 변환
+  const buffer = await workbook.xlsx.writeBuffer();
+  // Node.js에서는 Buffer 반환, 브라우저에서는 ArrayBuffer 반환
+  // Buffer가 정의되어 있고 이미 Buffer인 경우 그대로 반환
+  if (typeof Buffer !== 'undefined' && buffer instanceof Buffer) {
+    return buffer;
+  }
+  return Buffer.from(buffer);
+}

--- a/packages/core/src/formatters/excel-formatter.ts
+++ b/packages/core/src/formatters/excel-formatter.ts
@@ -1,0 +1,50 @@
+/**
+ * Excel 데이터 변환 로직
+ * Issue #113: 주문 목록 Excel 내보내기
+ */
+
+import type { Order } from '../types/order.js';
+import type { ExcelTableRow } from '../types/excel.js';
+
+/**
+ * Order 객체를 Excel 테이블 행으로 변환
+ *
+ * @param order - 주문 데이터
+ * @param index - 행 번호 (0-based)
+ * @returns Excel 테이블 행 데이터
+ */
+export function mapOrderToExcelRow(order: Order, index: number): ExcelTableRow {
+  // 수량은 Order 객체에 이미 계산되어 있음
+  const quantity = order.quantity;
+
+  // 품목명 결정 (productType 또는 validationError 사용)
+  let productType = '-';
+  if (order.validationError) {
+    // 검증 에러가 있으면 에러 메시지 표시
+    productType = `[오류] ${order.validationError}`;
+  } else if (order.productType) {
+    // 정상적인 상품 타입
+    productType = order.productType;
+  }
+
+  return {
+    번호: index + 1,
+    보내는분_성명: order.sender.name || '-',
+    보내는분_전화번호: order.sender.phone || '-',
+    받는분_주소: order.recipient.address || '-',
+    받는분_성명: order.recipient.name || '-',
+    받는분_전화번호: order.recipient.phone || '-',
+    수량: quantity,
+    품목명: productType,
+  };
+}
+
+/**
+ * 여러 주문을 Excel 테이블 행 배열로 변환
+ *
+ * @param orders - 주문 데이터 배열
+ * @returns Excel 테이블 행 배열
+ */
+export function mapOrdersToExcelRows(orders: Order[]): ExcelTableRow[] {
+  return orders.map((order, index) => mapOrderToExcelRow(order, index));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@
 // Types
 export * from './types/order.js';
 export * from './types/pdf.js';
+export * from './types/excel.js';
 
 // Config
 export { Config } from './config/config.js';
@@ -25,6 +26,7 @@ export {
 // Formatters
 export { LabelFormatter } from './formatters/label-formatter.js';
 export { mapOrderToPdfRow, mapOrdersToPdfRows } from './formatters/pdf-formatter.js';
+export { mapOrderToExcelRow, mapOrdersToExcelRows } from './formatters/excel-formatter.js';
 
 // Utils (추후 추가)
 // export * from './utils/phone.js';

--- a/packages/core/src/types/excel.ts
+++ b/packages/core/src/types/excel.ts
@@ -1,0 +1,33 @@
+/**
+ * Excel 관련 타입 정의
+ * Issue #113: 주문 목록 Excel 내보내기
+ */
+
+/**
+ * Excel 테이블 행 데이터
+ * PDF 테이블 행과 동일한 구조 사용
+ */
+export interface ExcelTableRow {
+  번호: number;
+  보내는분_성명: string;
+  보내는분_전화번호: string;
+  받는분_주소: string;
+  받는분_성명: string;
+  받는분_전화번호: string;
+  수량: number;
+  품목명: string;
+}
+
+/**
+ * Excel 생성 옵션
+ */
+export interface ExcelOptions {
+  /** 문서 제목 */
+  title?: string;
+  /** 시트 이름 */
+  sheetName?: string;
+  /** 생성 일시 포함 여부 */
+  includeTimestamp?: boolean;
+  /** 필터 조건 문자열 */
+  filterDescription?: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
+      exceljs:
+        specifier: ^4.4.0
+        version: 4.4.0
       fastify:
         specifier: ^4.0.0
         version: 4.29.1


### PR DESCRIPTION
## Summary

- PDF 내보내기와 동일한 동작을 하되 파일 형식만 Excel(.xlsx)로 변경
- exceljs 라이브러리를 사용한 Excel 생성
- 보안 취약점 방지 (Excel Formula Injection)

## 구현 내용

### Core 패키지
- `types/excel.ts`: ExcelTableRow, ExcelOptions 타입 정의
- `formatters/excel-formatter.ts`: 주문 데이터를 Excel 행으로 변환

### API 패키지
- `utils/excel-generator.ts`: exceljs를 사용한 Excel 버퍼 생성
  - `sanitizeForExcel`: Excel Formula Injection 방지
  - `sanitizeSheetName`: 시트 이름 새니타이징
- `routes/orders.ts`: GET/POST `/api/orders/report/excel` 엔드포인트 추가

### Web 패키지
- `app/labels/page.tsx`: Excel 다운로드 버튼 추가 (teal 색상)

## 코드 리뷰 반영 내역

### codex-cli 1차 리뷰
- [P0] Excel Formula Injection 취약점 → `sanitizeForExcel` 함수 추가
- [P1] Buffer 중복 복사 → 최적화 적용

### codex-cli 2차 리뷰
- [P1] 줄바꿈(\n) 포함 패턴 보강 → 정규식 패턴 확장
- [P2] 시트 이름 새니타이징 → `sanitizeSheetName` 함수 추가
- [P2] 브라우저 호환성 → Buffer 타입 체크 개선

## Test plan

- [ ] 라벨 페이지에서 Excel 버튼 클릭 시 다운로드 확인
- [ ] 생성된 Excel 파일 열기 및 데이터 확인
- [ ] 특수문자 포함 데이터 새니타이징 확인
- [ ] iOS Safari에서 다운로드 확인

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)