### PR TITLE
feat(web): 대시보드에 입금확인 주문 현황 패널 추가 (#130)

### DIFF
--- a/packages/api/src/routes/orders.ts
+++ b/packages/api/src/routes/orders.ts
@@ -1614,7 +1614,7 @@ const ordersRoutes: FastifyPluginAsync = async (fastify) => {
 
   /**
    * GET /api/orders/stats
-   * 통합 통계 조회 (완료/신규/전체 주문별, 기간별)
+   * 통합 통계 조회 (신규/입금확인/배송완료/전체 주문별, 기간별)
    */
   fastify.get<{
     Querystring: {
@@ -1633,14 +1633,14 @@ const ordersRoutes: FastifyPluginAsync = async (fastify) => {
       schema: {
         tags: ['orders'],
         summary: '통합 주문 통계 조회',
-        description: '완료된 주문 기반 통계를 조회합니다. 기간, 범위, 지표 등을 선택할 수 있습니다.',
+        description: '주문 통계를 조회합니다. scope로 상태별(신규/입금확인/배송완료/전체) 필터링이 가능합니다.',
         querystring: {
           type: 'object',
           properties: {
             scope: {
               type: 'string',
-              enum: ['completed', 'new', 'all'],
-              description: '통계 범위 (completed: 완료 주문, new: 신규 주문, all: 전체)',
+              enum: ['completed', 'new', 'pending_payment', 'all'],
+              description: '통계 범위 (completed: 배송완료, new: 신규주문, pending_payment: 입금확인, all: 전체)',
               default: 'completed',
             },
             range: {

--- a/packages/api/src/utils/stats.ts
+++ b/packages/api/src/utils/stats.ts
@@ -7,8 +7,12 @@ import type { Config } from '@mytangerine/core';
 
 /**
  * 통계 조회 범위
+ * - 'completed': 배송완료 주문
+ * - 'new': 신규주문
+ * - 'pending_payment': 입금확인 주문 (Issue #130)
+ * - 'all': 전체 주문
  */
-export type StatsScope = 'completed' | 'new' | 'all';
+export type StatsScope = 'completed' | 'new' | 'pending_payment' | 'all';
 
 /**
  * 기간 범위

--- a/packages/web/src/app/dashboard/page.tsx
+++ b/packages/web/src/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { SummaryCard } from '@/components/dashboard/SummaryCard';
 import { RecentOrders } from '@/components/dashboard/RecentOrders';
 import { QuickActions } from '@/components/dashboard/QuickActions';
 import { NewOrdersPanel } from '@/components/dashboard/NewOrdersPanel';
+import { PendingPaymentPanel } from '@/components/dashboard/PendingPaymentPanel';
 import { OrderStatsPanel } from '@/components/dashboard/OrderStatsPanel';
 
 export default function DashboardPage() {
@@ -28,11 +29,16 @@ export default function DashboardPage() {
           </div>
         </div>
 
-        {/* 중앙: 신규 주문 현황 + 완료 주문 통계 (2열) */}
-        <div className="mt-8 grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* 중앙: 주문 상태별 현황 (3열: 신규 → 입금확인 → 완료) */}
+        <div className="mt-8 grid grid-cols-1 md:grid-cols-3 gap-6">
           {/* 신규 주문 현황 */}
           <div className="bg-white rounded-xl shadow-sm p-6">
             <NewOrdersPanel />
+          </div>
+
+          {/* 입금확인 주문 현황 (Issue #130) */}
+          <div className="bg-white rounded-xl shadow-sm p-6">
+            <PendingPaymentPanel />
           </div>
 
           {/* 완료 주문 통계 (컴팩트 모드) */}

--- a/packages/web/src/components/dashboard/PendingPaymentPanel.tsx
+++ b/packages/web/src/components/dashboard/PendingPaymentPanel.tsx
@@ -1,0 +1,116 @@
+/**
+ * 입금확인 주문 현황 패널
+ * Issue #130: 입금확인 상태 주문 통계를 표시하고 목록으로 이동하는 링크 제공
+ */
+
+'use client';
+
+import Link from 'next/link';
+import { useOrderStats } from '@/hooks/use-stats';
+import { Card } from '@/components/common/Card';
+import { CreditCard, TrendingUp, Gift, ShoppingCart, ArrowRight } from 'lucide-react';
+
+export function PendingPaymentPanel() {
+  const { data, isLoading, error } = useOrderStats({
+    scope: 'pending_payment',
+    metric: 'quantity',
+  });
+
+  if (isLoading) {
+    return (
+      <Card title="입금확인 주문 현황">
+        <div className="animate-pulse space-y-3">
+          <div className="h-16 bg-gray-200 rounded"></div>
+          <div className="h-16 bg-gray-200 rounded"></div>
+        </div>
+      </Card>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <Card title="입금확인 주문 현황">
+        <div className="text-gray-500 text-sm">
+          데이터를 불러올 수 없습니다.
+        </div>
+      </Card>
+    );
+  }
+
+  const { summary, sections } = data;
+
+  // 선물 비율 계산
+  const giftCount = sections?.gifts?.orderCount || 0;
+  const salesCount = sections?.sales?.orderCount || 0;
+  const totalCount = summary.orderCount;
+
+  return (
+    <Card title="입금확인 주문 현황">
+      <div className="space-y-4">
+        {/* 입금확인 건수 */}
+        <div className="flex items-center justify-between p-4 bg-green-50 rounded-lg">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-green-100 rounded-lg">
+              <CreditCard className="h-5 w-5 text-green-600" />
+            </div>
+            <div>
+              <p className="text-sm text-gray-600">입금확인</p>
+              <p className="text-2xl font-bold text-green-600">
+                {totalCount}건
+              </p>
+            </div>
+          </div>
+          <div className="text-right">
+            <p className="text-sm text-gray-600">예상 매출</p>
+            <p className="text-lg font-semibold text-gray-900">
+              {summary.totalRevenue.toLocaleString()}원
+            </p>
+          </div>
+        </div>
+
+        {/* 판매/선물 비율 */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="flex items-center gap-2 p-3 bg-blue-50 rounded-lg">
+            <ShoppingCart className="h-4 w-4 text-blue-600" />
+            <div>
+              <p className="text-xs text-gray-600">판매</p>
+              <p className="text-lg font-bold text-blue-600">{salesCount}건</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 p-3 bg-purple-50 rounded-lg">
+            <Gift className="h-4 w-4 text-purple-600" />
+            <div>
+              <p className="text-xs text-gray-600">선물</p>
+              <p className="text-lg font-bold text-purple-600">{giftCount}건</p>
+            </div>
+          </div>
+        </div>
+
+        {/* 상품별 수량 */}
+        <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+          <div className="flex items-center gap-2">
+            <TrendingUp className="h-4 w-4 text-gray-600" />
+            <span className="text-sm text-gray-600">상품 구성</span>
+          </div>
+          <div className="flex gap-4 text-sm">
+            <span className="text-orange-600 font-medium">
+              5kg: {summary.total5kgQty}박스
+            </span>
+            <span className="text-green-600 font-medium">
+              10kg: {summary.total10kgQty}박스
+            </span>
+          </div>
+        </div>
+
+        {/* 주문 목록 링크 */}
+        <Link
+          href="/orders?status=pending_payment"
+          className="flex items-center justify-center gap-2 p-3 bg-green-600 hover:bg-green-700 text-white rounded-lg transition-colors"
+        >
+          <span className="text-sm font-medium">입금확인 주문 목록 보기</span>
+          <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+    </Card>
+  );
+}

--- a/packages/web/src/types/api.ts
+++ b/packages/web/src/types/api.ts
@@ -120,8 +120,12 @@ export interface GroupedLabelsResponse {
 
 /**
  * 통합 통계 타입
+ * - 'completed': 배송완료 주문
+ * - 'new': 신규주문
+ * - 'pending_payment': 입금확인 주문 (Issue #130)
+ * - 'all': 전체 주문
  */
-export type StatsScope = 'completed' | 'new' | 'all';
+export type StatsScope = 'completed' | 'new' | 'pending_payment' | 'all';
 export type StatsRange = '6m' | '12m' | 'custom';
 export type StatsGrouping = 'monthly';
 export type StatsMetric = 'quantity' | 'amount';


### PR DESCRIPTION
## 변경 사항 요약
대시보드에 "입금확인" 주문 현황 패널을 추가하여 주문 상태 흐름(신규주문 → 입금확인 → 배송완료)을 한눈에 볼 수 있게 개선했습니다.

## 변경된 파일
1. `packages/web/src/components/dashboard/PendingPaymentPanel.tsx` (신규)
   - 입금확인 상태 주문 통계 표시 (건수, 예상매출)
   - 판매/선물 비율 표시
   - 상품 구성 (5kg/10kg) 표시
   - 입금확인 주문 목록 링크 제공

2. `packages/web/src/app/dashboard/page.tsx`
   - `PendingPaymentPanel` import 추가
   - 중앙 그리드를 3열로 변경 (신규 → 입금확인 → 완료)

3. `packages/api/src/utils/stats.ts`
   - `StatsScope` 타입에 `pending_payment` 추가

4. `packages/api/src/routes/orders.ts`
   - `/api/orders/stats` 스키마에 `pending_payment` scope 추가
   - JSDoc 및 description 문구 업데이트

5. `packages/web/src/types/api.ts`
   - `StatsScope` 타입에 `pending_payment` 추가 (API와 동기화)

## 코드 리뷰 반영 내역
#### codex-cli 1차 리뷰
- [High] `/api/orders/stats` 스키마 enum에 `pending_payment` 누락 → 수정 완료
- [Low] md 그리드 레이아웃 불균형 → `md:grid-cols-3`으로 수정

#### codex-cli 2차 리뷰
- [Low] description 문구 불일치 → 범용적 문구로 수정

#### codex-cli 3차 리뷰
- [Low] JSDoc 주석 불일치 → 업데이트 완료

#### codex-cli 4차 리뷰
- 추가 이슈 없음 ✅

## 테스트
- [x] 빌드 성공 확인

Closes #130

---
codex-cli 분석 기반으로 작성됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)