### PR TITLE
feat(web): 주문 항목 유효성 검사 UI (#115)

### DIFF
--- a/packages/web/src/app/orders/OrdersPageContent.tsx
+++ b/packages/web/src/app/orders/OrdersPageContent.tsx
@@ -212,8 +212,11 @@ export function OrdersPageContent() {
     updateQueryParams({ productType: value, page: 1 });
   };
 
-  const handleValidationFilterChange = (value: ValidationFilter) => {
-    updateQueryParams({ validation: value === 'all' ? '' : value, page: 1 });
+  const handleValidationFilterChange = (value: string) => {
+    // 허용된 값만 처리, 그 외는 'all'로 정규화
+    const normalizedValue: ValidationFilter =
+      value === 'errors' || value === 'valid' ? value : 'all';
+    updateQueryParams({ validation: normalizedValue === 'all' ? '' : normalizedValue, page: 1 });
   };
 
   const handleSortChange = (field?: SortField, order?: SortOrder) => {

--- a/packages/web/src/components/orders/OrdersTable.tsx
+++ b/packages/web/src/components/orders/OrdersTable.tsx
@@ -14,6 +14,10 @@ interface OrdersTableProps {
   showDeleted?: boolean;
 }
 
+/** 검증 오류 여부 확인 헬퍼 (빈 문자열 방어) */
+const hasValidationError = (order: Order): boolean =>
+  Boolean(order.validationError && order.validationError.trim() !== '');
+
 export function OrdersTable({ orders, searchParams, showDeleted = false }: OrdersTableProps) {
   const router = useRouter();
 
@@ -67,14 +71,14 @@ export function OrdersTable({ orders, searchParams, showDeleted = false }: Order
               key={order.rowNumber}
               onClick={() => handleRowClick(order.rowNumber)}
               className={`transition-colors cursor-pointer ${
-                order.validationError && order.validationError.trim() !== ''
+                hasValidationError(order)
                   ? 'bg-red-50 hover:bg-red-100'
                   : 'hover:bg-gray-50'
               } ${order.isDeleted ? 'opacity-60' : ''}`}
             >
               <td className="px-6 py-4 whitespace-nowrap">
                 <div className="flex items-center gap-2">
-                  {order.validationError && order.validationError.trim() !== '' && (
+                  {hasValidationError(order) && (
                     <span
                       className="text-red-500"
                       title={order.validationError}
@@ -105,7 +109,7 @@ export function OrdersTable({ orders, searchParams, showDeleted = false }: Order
                 {order.recipient.phone}
               </td>
               <td className="px-6 py-4 whitespace-nowrap">
-                {order.validationError && order.validationError.trim() !== '' ? (
+                {hasValidationError(order) ? (
                   <span className="inline-block px-3 py-1 rounded-full text-sm font-medium bg-red-100 text-red-700">
                     오류: {order.validationError}
                   </span>


### PR DESCRIPTION
# 주문 항목 유효성 검사 UI (Web 계층 일부) — #115

## 개요
Core/API/Web 전체 유효성 검사 시스템 중, 이번 PR은 Web 계층의 UI 일부만 구현합니다.  
관리자 페이지에서 검증 실패 주문을 필터링하고, 오류가 있는 행을 시각적으로 강조합니다.

## 구현 범위
- ✅ 관리자 페이지: 검증 실패 주문 필터 UI
- ✅ 검증 오류 행 하이라이팅
- ❌ 입력 폼 실시간 검증 (이번 PR 범위 외)
- ❌ 정정 UI (이번 PR 범위 외)

## 주요 변경사항
### 검증 상태 필터
- URL 쿼리 파라미터 기반 필터: `?validation=all|errors|valid`
- 허용되지 않은 값은 `all`로 정규화
- 기존 상태/상품 필터와 함께 동작

### 테이블 하이라이팅
- 검증 오류 행: `bg-red-50`, `hover:bg-red-100`
- 경고 아이콘(⚠️) 표시 with `aria-label`, `role="img"`
- 상품 컬럼에 오류 배지 표시

### 빈 문자열 처리
- 모든 검증 로직에서 `trim()` 기반으로 일관 처리
- `hasValidationError` 헬퍼 함수로 조건 통일

## 변경 파일
- `packages/web/src/app/orders/OrdersPageContent.tsx`
- `packages/web/src/components/orders/OrdersTable.tsx`

## 테스트 방법
1. `/orders` 페이지 접속
2. 검증 상태 필터 드롭다운으로 '오류만', '정상만' 선택
3. URL 파라미터가 정상 반영되는지 확인
4. 검증 오류가 있는 주문이 빨간 배경으로 표시되는지 확인
5. 경고 아이콘에 마우스 호버 시 오류 내용 표시되는지 확인

## 코드 리뷰 이력 반영
- 1차: URL 쿼리 정규화, aria-label, 빈 문자열 처리 → 반영 완료
- 2차: 상품 컬럼 오류 배지 빈 문자열 처리 일관성 → 반영 완료
- 3차: handleValidationFilterChange 정규화, hasValidationError 헬퍼 도입 → 반영 완료
- 4차: No findings ✅

---
codex-cli 분석 기반으로 작성됨

Closes #115