### PR TITLE
feat(dashboard): Phase 2 - 시즌 오버레이 및 KPI Alerts (#112)

### DIFF
--- a/packages/web/src/components/dashboard/QuickActions.tsx
+++ b/packages/web/src/components/dashboard/QuickActions.tsx
@@ -1,19 +1,67 @@
 /**
  * 빠른 액션 버튼 컴포넌트
+ * Issue #112: KPI Alerts 기능 추가
  */
 
 'use client';
 
 import Link from 'next/link';
 import { useSyncData } from '@/hooks/use-sync';
+import { useOrderStats } from '@/hooks/use-stats';
+import { useOrdersSummary } from '@/hooks/use-orders';
 import { Card } from '@/components/common/Card';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { AlertTriangle, TrendingDown, PackageX } from 'lucide-react';
+import type { KPIAlert } from '@/types/api';
+
+/** MoM 감소 임계값 (%) */
+const MOM_DECLINE_THRESHOLD = -10;
 
 export function QuickActions() {
   const syncMutation = useSyncData();
   const [syncMessage, setSyncMessage] = useState<string | null>(null);
   const [syncErrors, setSyncErrors] = useState<Array<{ rowNumber: number; error: string }> | null>(null);
   const syncTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // KPI 데이터 조회
+  const { data: newOrdersData } = useOrdersSummary();
+  const { data: trendData } = useOrderStats({
+    scope: 'completed',
+    range: '6m',
+    metric: 'amount',
+  });
+
+  // KPI Alerts 계산
+  const alerts = useMemo(() => {
+    const result: KPIAlert[] = [];
+
+    // 1. 신규 주문 없음 알림
+    const newOrderCount = newOrdersData?.summary
+      ? newOrdersData.summary['5kg'].count + newOrdersData.summary['10kg'].count
+      : 0;
+
+    if (newOrdersData?.success && newOrderCount === 0) {
+      result.push({
+        type: 'info',
+        title: '신규 주문 없음',
+        message: '처리 대기 중인 신규 주문이 없습니다.',
+      });
+    }
+
+    // 2. MoM 감소 경고
+    const latestSeries = trendData?.series?.slice(-1)[0];
+    const momGrowthPct = latestSeries?.momGrowthPct;
+
+    if (momGrowthPct !== null && momGrowthPct !== undefined && momGrowthPct < MOM_DECLINE_THRESHOLD) {
+      result.push({
+        type: 'warning',
+        title: '매출 감소 경고',
+        message: `전월 대비 매출이 ${momGrowthPct.toFixed(1)}% 감소했습니다.`,
+      });
+    }
+
+    return result;
+  }, [newOrdersData, trendData]);
 
   useEffect(() => {
     return () => {
@@ -24,6 +72,12 @@ export function QuickActions() {
   }, []);
 
   const handleSync = async () => {
+    // codex-cli 리뷰: 기존 타이머를 정리하여 중첩 방지
+    if (syncTimeoutRef.current) {
+      clearTimeout(syncTimeoutRef.current);
+      syncTimeoutRef.current = null;
+    }
+
     try {
       const result = await syncMutation.mutateAsync();
       setSyncMessage(result.message);
@@ -46,9 +100,51 @@ export function QuickActions() {
     }
   };
 
+  /** Alert 아이콘 선택 */
+  const getAlertIcon = (type: KPIAlert['type']) => {
+    switch (type) {
+      case 'warning':
+        return <TrendingDown className="h-4 w-4" />;
+      case 'info':
+        return <PackageX className="h-4 w-4" />;
+      default:
+        return <AlertTriangle className="h-4 w-4" />;
+    }
+  };
+
+  /** Alert 스타일 */
+  const getAlertStyle = (type: KPIAlert['type']) => {
+    switch (type) {
+      case 'warning':
+        return 'bg-amber-50 border-amber-200 text-amber-800';
+      case 'info':
+        return 'bg-blue-50 border-blue-200 text-blue-700';
+      default:
+        return 'bg-green-50 border-green-200 text-green-700';
+    }
+  };
+
   return (
     <Card title="빠른 작업">
       <div className="space-y-3">
+        {/* KPI Alerts */}
+        {alerts.length > 0 && (
+          <div className="space-y-2 pb-3 border-b border-gray-200">
+            {alerts.map((alert, idx) => (
+              <div
+                key={idx}
+                className={`flex items-start gap-2 p-2 rounded-lg border ${getAlertStyle(alert.type)}`}
+              >
+                <span className="mt-0.5 flex-shrink-0">{getAlertIcon(alert.type)}</span>
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium text-sm">{alert.title}</p>
+                  <p className="text-xs opacity-80">{alert.message}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
         <Link
           href="/orders"
           className="block w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium text-center transition-colors"

--- a/packages/web/src/types/api.ts
+++ b/packages/web/src/types/api.ts
@@ -202,3 +202,15 @@ export interface StatsResponse {
     currency: 'KRW';
   };
 }
+
+/**
+ * KPI Alert 타입
+ * Issue #112: 대시보드 KPI 알림 기능
+ */
+export type KPIAlertType = 'warning' | 'info' | 'success';
+
+export interface KPIAlert {
+  type: KPIAlertType;
+  title: string;
+  message: string;
+}


### PR DESCRIPTION
## Summary

- P0-2: AreaChartStats에 시즌 오버레이 추가, 성수기(10~2월) 구간 하이라이트 및 seasonRanges useMemo 최적화
- P0-5: QuickActions에 KPI 알림 배지 추가, 매출 MoM -10% 경고/신규 주문 0건 알림 처리 및 KPIAlert 타입 정의
- codex-cli 리뷰 반영: 시즌 오버레이 x축을 fullDate 기준으로 변경, 동기화 타이머 중첩 방지
- P0-3: seasonal scope는 백엔드 Stats API 작업 필요로 별도 이슈 분리

## 구현 세부사항

### P0-2: Lifecycle Heatmap (시즌 오버레이)
- `AreaChartStats`에 `showSeasonOverlay` prop 추가
- 성수기(10~2월) 구간을 `ReferenceArea`로 하이라이트
- `isPeakSeason()` 함수로 월 판단
- `useMemo`로 `seasonRanges` 계산 최적화

### P0-5: KPI Alerts
- `QuickActions`에 알림 배지 추가
- MoM -10% 이하 시 매출 감소 경고 (warning)
- 신규 주문 0건 시 알림 (info)
- `KPIAlert`, `KPIAlertType` 타입 추가

### P0-3: seasonal scope
- 백엔드 Stats API에 'seasonal' scope 추가 필요
- 프론트엔드만으로는 구현 불가, 별도 이슈로 분리 예정

## codex-cli 리뷰 반영 내역

| 우선순위 | 이슈 | 해결 방법 |
|---------|------|----------|
| Medium | 시즌 오버레이 x축 기준이 표시용 레이블이라 다년 데이터에서 오정렬 | `fullDate` (YYYY-MM)를 x축 기준으로 변경, `tickFormatter`로 월 표시 유지 |
| Low | 동기화 버튼 연속 클릭 시 타이머 중첩 | `handleSync` 시작 시 기존 타이머 `clearTimeout` |

## Test plan

- [ ] 대시보드 접속 → KPI 알림 배지 표시 확인
- [ ] 통계 페이지 → 시즌 오버레이 표시 확인 (showSeasonOverlay prop 활성화 필요)
- [ ] 다년 데이터(12개월 이상)에서 시즌 오버레이 정확한 위치 확인
- [ ] 동기화 버튼 연속 클릭 시 메시지 표시 동작 확인

Closes #112 Phase 2

---
codex-cli 분석 기반으로 작성됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)