### PR TITLE
fix(core): Issue #152 배송사고 주문 생성 시 Google Sheets 동기화 누락 수정

### DIFF
--- a/packages/core/src/services/hybrid-data-service.ts
+++ b/packages/core/src/services/hybrid-data-service.ts
@@ -15,6 +15,17 @@ import type { SheetRow, OrderStatus } from '../types/order.js';
 
 export type DataSourceMode = 'sheets' | 'database' | 'hybrid';
 
+/**
+ * 배송사고 주문 생성 결과 (Issue #152)
+ */
+export interface CreateClaimOrderResult {
+  rowNumber: number;
+  sheetsSynced: boolean;
+  sheetsRowNumber?: number;  // 6차 리뷰: 실제 Sheets 행 번호
+  rowNumberMismatch?: boolean;  // 6차 리뷰: DB-Sheets row number 불일치 여부
+  sheetsError?: string;
+}
+
 export interface HybridDataServiceOptions {
   mode: DataSourceMode;
   /** hybrid 모드에서 DB 실패 시 Sheets fallback 여부 (기본: true) */
@@ -569,16 +580,112 @@ export class HybridDataService {
   /**
    * 배송사고 주문 생성 (Issue #152)
    * 원본 주문을 복제하여 orderType='claim'인 새 주문 생성
+   *
    * @param originalRowNumber - 원본 주문의 행 번호
-   * @returns 생성된 주문의 행 번호
+   * @returns 생성 결과 (행 번호 + Sheets 동기화 상태)
+   *
+   * @note DB의 sheetRowNumber는 max+1로 생성되고, Sheets는 append로 마지막 행에 추가됩니다.
+   *       시트에 공백 행이나 수동 삽입이 있으면 두 값이 달라질 수 있습니다.
+   *       이 경우 sync-service의 전체 동기화(fullResync)로 정합성을 맞출 수 있습니다.
    */
-  async createClaimOrder(originalRowNumber: number): Promise<number> {
+  async createClaimOrder(originalRowNumber: number): Promise<CreateClaimOrderResult> {
     if (this.mode === 'sheets') {
       throw new Error('createClaimOrder is not supported in sheets mode');
     }
 
-    // database 또는 hybrid 모드에서만 지원
-    return this.databaseService.createClaimOrder(originalRowNumber);
+    if (this.mode === 'database') {
+      const rowNumber = await this.databaseService.createClaimOrder(originalRowNumber);
+      return { rowNumber, sheetsSynced: false };
+    }
+
+    // hybrid: DB + Sheets 동시 생성
+    let newRowNumber: number;
+
+    // 1. DB에 먼저 생성
+    try {
+      newRowNumber = await this.databaseService.createClaimOrder(originalRowNumber);
+      this.logger?.info(`[hybrid] createClaimOrder DB success: row ${newRowNumber}`);
+    } catch (dbError) {
+      // DB 실패 시 전체 실패
+      throw dbError;
+    }
+
+    // 2. Sheets에도 추가 (DB 성공 후)
+    try {
+      // 3차 리뷰: DB가 소스 오브 트루스이므로 DB에서 원본 조회
+      const originalOrder = await this.databaseService.getRawOrderByRowNumber(originalRowNumber);
+      if (!originalOrder) {
+        throw new Error(`Original order not found at row ${originalRowNumber}`);
+      }
+
+      // 현재 시각 (한국어 형식)
+      const now = new Date();
+      const timestampRaw = now.toLocaleString('ko-KR', {
+        year: 'numeric',
+        month: 'numeric',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+        second: 'numeric',
+        hour12: true,
+      });
+
+      // Sheets 컬럼 데이터 구성 (DB 원본에서 복제 + 배송사고 설정)
+      // DB 필드명 -> Sheets 컬럼명 매핑
+      // 4차 리뷰: quantity는 '0'을 ''로 정규화하고 String() 처리
+      const normalizeQuantity = (val: string | null | undefined): string => {
+        if (!val || val === '0') return '';
+        return String(val);
+      };
+
+      const sheetRowData: Record<string, string> = {
+        '타임스탬프': timestampRaw,
+        '주문자 성함': originalOrder.ordererName || '',
+        '이메일 주소': originalOrder.ordererEmail || '',
+        '보내는분 성함': originalOrder.senderName || '',
+        '보내는분 연락처 (핸드폰번호)': originalOrder.senderPhone || '',
+        '보내는분 주소 (도로명 주소로 부탁드려요)': originalOrder.senderAddress || '',
+        '받으실분 성함': originalOrder.recipientName || '',
+        '받으실분 연락처 (핸드폰번호)': originalOrder.recipientPhone || '',
+        '받으실분 주소 (도로명 주소로 부탁드려요)': originalOrder.recipientAddress || '',
+        '상품 선택': originalOrder.productSelection || '',
+        '5kg 수량': normalizeQuantity(originalOrder.quantity5kg),
+        '10kg 수량': normalizeQuantity(originalOrder.quantity10kg),
+        '주문유형': '배송사고',
+        '비고': '신규주문',
+      };
+
+      const actualSheetRowNumber = await this.sheetService!.appendRow(sheetRowData);
+      this.logger?.info(`[hybrid] createClaimOrder Sheets success: appended at row ${actualSheetRowNumber}`);
+
+      // 5차 리뷰: row number 불일치 경고 (fullResync로 해결 가능)
+      const hasMismatch = actualSheetRowNumber !== newRowNumber;
+      if (hasMismatch) {
+        this.logger?.warn(
+          `[hybrid] Row number mismatch: DB=${newRowNumber}, Sheet=${actualSheetRowNumber}. ` +
+          `Run fullResync to reconcile.`
+        );
+      }
+
+      // 6차 리뷰: 불일치 정보도 결과에 포함
+      return {
+        rowNumber: newRowNumber,
+        sheetsSynced: true,
+        sheetsRowNumber: actualSheetRowNumber,
+        rowNumberMismatch: hasMismatch,
+      };
+    } catch (sheetsError) {
+      const errorMessage = sheetsError instanceof Error ? sheetsError.message : String(sheetsError);
+      this.logger?.error(`[hybrid] createClaimOrder Sheets failed: ${errorMessage}`);
+      this.logger?.warn(`[hybrid] Claim order created in DB but Sheets sync failed. Row: ${newRowNumber}`);
+
+      // Sheets 실패해도 DB는 성공했으므로 결과에 상태 포함하여 반환
+      return {
+        rowNumber: newRowNumber,
+        sheetsSynced: false,
+        sheetsError: errorMessage,
+      };
+    }
   }
 
   /**

--- a/packages/web/src/lib/api-client.ts
+++ b/packages/web/src/lib/api-client.ts
@@ -382,6 +382,10 @@ export async function createClaimOrder(rowNumber: number): Promise<{
     claimOrderId: number;
     originalOrderId: number;
     message: string;
+    sheetsSynced: boolean;
+    sheetsRowNumber?: number;
+    rowNumberMismatch?: boolean;
+    sheetsError?: string;
   };
 }> {
   return api.post(`api/orders/${rowNumber}/claim`, { json: {} }).json<{
@@ -390,6 +394,10 @@ export async function createClaimOrder(rowNumber: number): Promise<{
       claimOrderId: number;
       originalOrderId: number;
       message: string;
+      sheetsSynced: boolean;
+      sheetsRowNumber?: number;
+      rowNumberMismatch?: boolean;
+      sheetsError?: string;
     };
   }>();
 }


### PR DESCRIPTION
## Summary

- **Issue #152**: 배송사고(claim) 주문 생성 시 hybrid 모드에서 Google Sheets에 저장되지 않는 버그 수정

## 변경 사항

### SheetService.appendRow 추가
- Google Sheets에 새 행을 추가하는 메서드
- 행 번호 파싱 정규식 보강 (콜론 유무 모두 허용)

### HybridDataService.createClaimOrder 수정
- hybrid 모드: DB + Sheets 동시 저장
- DB를 소스 오브 트루스로 사용 (Sheets 대신 DB에서 원본 조회)
- `CreateClaimOrderResult` 인터페이스로 상세 결과 반환
- row number 불일치 감지 및 경고 로그

### API/Web 타입 업데이트
- 응답에 `sheetsSynced`, `sheetsRowNumber`, `rowNumberMismatch` 필드 추가

## 수정 파일
- `packages/core/src/services/sheet-service.ts`
- `packages/core/src/services/hybrid-data-service.ts`
- `packages/api/src/routes/orders.ts`
- `packages/web/src/lib/api-client.ts`

## 코드 리뷰 이력 (7차)

| 차수 | 이슈 | 해결 |
|------|------|------|
| 1차 | appendRow 파싱 보강, 결과 객체 | 정규식 보강, 인터페이스 추가 |
| 2차 | Web 타입 누락 | 타입 추가 |
| 3차 | Sheets 대신 DB에서 원본 조회, 주문자 필드 누락 | DB 조회, 필드 추가 |
| 4차 | quantity '0' 정규화 | normalizeQuantity 함수 |
| 5차 | row mismatch 경고 | 로그 추가 |
| 6차 | 불일치 정보 결과 포함 | sheetsRowNumber, rowNumberMismatch |
| 7차 | 통과 | - |

## Test plan

- [ ] 배송완료 주문에서 "배송사고 등록" 버튼 클릭
- [ ] 배송사고 주문이 DB에 생성되었는지 확인
- [ ] Google Sheets에 새 행이 추가되었는지 확인
- [ ] API 응답에 sheetsSynced=true, sheetsRowNumber 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)